### PR TITLE
replace class(x)=* with inherits(x,*)

### DIFF
--- a/R/CV_mlm.R
+++ b/R/CV_mlm.R
@@ -11,7 +11,7 @@
 #' @importFrom forecast CV
 CV_mlm <- function (obj) 
 {
-  if(class(obj)[[1]]=="lm"){
+  if(inherits(obj, "lm")){
     return(forecast::CV(obj)[c("CV", "AICc", "AdjR2")] %>%
       as.matrix() %>%
       t() %>%

--- a/R/error_paleocar_models.R
+++ b/R/error_paleocar_models.R
@@ -36,7 +36,7 @@ uncertainty_paleocar_models <- function(models,
     errors <- matrix(errors)
   }
   
-  if(class(models$predictands) %in% c("RasterBrick","RasterStack")){
+  if(inherits(predictands, c("RasterBrick", "RasterStack"))){
     na.errors <- matrix(data=NA,
                         nrow=length(prediction.years),
                         ncol=raster::ncell(models$predictands))

--- a/R/paleocar_models.R
+++ b/R/paleocar_models.R
@@ -75,7 +75,7 @@ paleocar_models <- function(chronologies,
   
   maxPreds <- nrow(predictor.matrix) - 5
   
-  if (class(predictands) %in% c("RasterBrick", "RasterStack")) {
+  if (inherits(predictands, c("RasterBrick", "RasterStack"))) {
     if (raster::nlayers(predictands) != length(calibration.years)) {
       stop(
         "Predictand raster must have the same number of layers as the length of the calibration.years vector!"
@@ -344,7 +344,7 @@ paleocar_models <- function(chronologies,
         tibble::as_tibble(rownames = "cell") %>%
         dplyr::mutate(model = this.model)
       
-      if ("mlm" %in% class(model.mlm)) {
+      if (inherits(model.mlm, "mlm")) {
         model.mlm %<>%
           unlist_mlm() %>%
           purrr::map(function(x){attr(x$terms, "term.labels")}) %>%

--- a/R/predict_paleocar_models.R
+++ b/R/predict_paleocar_models.R
@@ -79,7 +79,7 @@ predict_paleocar_models <- function(models,
     lms <- lm(response ~ .,
               data = terms)
     
-    if(!("mlm" %in% class(lms))){
+    if(!inherits(lms, "mlm")){
       
       x %>%
         dplyr::select(cell, year, endYear) %>%
@@ -163,7 +163,7 @@ predict_paleocar_models <- function(models,
     dplyr::arrange(cell, year)
   
   
-  if (class(models$predictands)[[1]] %in% c("RasterBrick", "RasterStack")) {
+  if (inherits(models$predictands, c("RasterBrick", "RasterStack"))) {
     out %<>% 
       dplyr::arrange(year, cell) %>%
       dplyr::group_by(year) %>%


### PR DESCRIPTION
I was getting a "condition has length > 1" error when using a matrix because it has class `matrix` and `array` so it was returning multiple truth values in `if (class(x)==*)` statements. `inherits()` always returns a scalar (checks for any matches), so it should be more appropriate in this context, at least I think that's right anyway.